### PR TITLE
Restore http support

### DIFF
--- a/bin/rajce-get
+++ b/bin/rajce-get
@@ -13,7 +13,7 @@ use WebService::Rajce;
 use Getopt::Long qw(GetOptions);
 Getopt::Long::Configure qw(gnu_getopt);
 
-my $url_pattern="^https:\/\/(.*)\.rajce\.idnes\.cz\/(.*)";
+my $url_pattern="^(https?):\/\/(.*)\.rajce\.idnes\.cz\/(.*)";
 
 $|++;
 
@@ -44,9 +44,9 @@ if(!$opt{u} or $opt{u} !~ /$url_pattern/ or $opt{h}){
 	exit;
 }
 
-my ($username,$album) = $opt{u} =~ $url_pattern;
+my ($schema,$username,$album) = $opt{u} =~ $url_pattern;
 
-my $url = "https://$username.rajce.idnes.cz/$album";
+my $url = "$schema://$username.rajce.idnes.cz/$album";
 
 my $bot = WWW::Mechanize->new(autocheck => 1, agent => 'rajce-get/'.$version);
 $bot->env_proxy();
@@ -122,6 +122,7 @@ directory username/album
 
 Behind proxy server try:
 
+export http_proxy=http://login:password@proxyserver:port
 export https_proxy=http://login:password@proxyserver:port
 
 =head1 EXAMPLES


### PR DESCRIPTION
This patch allows rajce-get to fetch from http URL again.

<https://github.com/petrkle/webservice-rajce/issues/5>